### PR TITLE
Validate `getDamageSource` is not null before dereferencing

### DIFF
--- a/src/main/java/com/example/upgradedwolves/common/WolfPlayerInteraction.java
+++ b/src/main/java/com/example/upgradedwolves/common/WolfPlayerInteraction.java
@@ -295,7 +295,7 @@ public class WolfPlayerInteraction {
 
     @SubscribeEvent
     public void SetLoot(LootingLevelEvent event){
-        if(event.getDamageSource().getDirectEntity() instanceof ServerPlayer || event.getDamageSource().getDirectEntity() instanceof Wolf){
+        if(event.getDamageSource() != null && (event.getDamageSource().getDirectEntity() instanceof ServerPlayer || event.getDamageSource().getDirectEntity() instanceof Wolf)){
             LivingEntity user = (LivingEntity)event.getDamageSource().getDirectEntity();
             EntityFinder<Wolf> entityFinder = new EntityFinder<Wolf>(user,Wolf.class);
             List<Wolf> wolves = entityFinder.findWithPredicate(10, 10,wolf -> wolf.getOwner() == user);


### PR DESCRIPTION
`event.getDamageSource()` is not guaranteed to be not null, hence accessing the `getDirectEntity()` may result in a null pointer error. 

This error prevents players from opening containers with loot tables. Unfortunately, it also appears to happen within the network interface, meaning that it fails silently without alerting players as to why containers cannot be opened.

Specifically, this issue was reported to me on the Lootr discord due to a player having this issue. The relevant log can be found [here](https://gist.github.com/noobanidus/f8b14b59c574dd3587f68074dae2f561).

NB: This pull request was made via the GitHub interface and I have not personally compiled it. There's no reason why there should be an error, due to the simplicity of the fix, but you may want to confirm before pushing any updates.